### PR TITLE
Rename Coontrols component to Controls

### DIFF
--- a/src/Components/Controls.jsx
+++ b/src/Components/Controls.jsx
@@ -12,7 +12,7 @@ import notify from "../assets/tap.wav";
 import firstSlide from "../assets/arrow-end-left-icon.svg";
 import lastSlide from "../assets/arrow-end-right-icon.svg";
 
-const Coontrols = forwardRef((props, ref) => {
+const Controls = forwardRef((props, ref) => {
   const [range, setRange] = useState(0);
   let { dark, state } = useContext(Context);
   let { showexit } = useContext(AppContext);
@@ -177,4 +177,4 @@ const Coontrols = forwardRef((props, ref) => {
   );
 });
 
-export default Coontrols;
+export default Controls;

--- a/src/Components/Home.jsx
+++ b/src/Components/Home.jsx
@@ -8,7 +8,7 @@ import React, {
 import { useNavigate } from "react-router-dom";
 import Time from "./Time";
 import Nav from "./Nav";
-import Coontrols from "./Coontrols";
+import Controls from "./Controls";
 import Settings from "./Settings";
 import { Context } from "../App";
 import Confirmation from "./Confirmation";
@@ -118,7 +118,7 @@ export default function Home({ socket }) {
         >
           <Nav disconnectSocket={disconnectSocket} />
           <Time />
-          <Coontrols handleControl={handleControl} ref={myRef} />
+          <Controls handleControl={handleControl} ref={myRef} />
           <p
             style={{ marginTop: "-70px" }}
             className="text-center text-[var(--text)]"


### PR DESCRIPTION
I fixed a typo in the component name "Coontrols" to "Controls". In addition, l also changed the necessary files such as the `Home.jsx` which also includes some imports about the Controls.